### PR TITLE
Update slf4j package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,13 +133,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.35</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-simple</artifactId>
-          <version>1.7.35</version>
-          <scope>test</scope>
+          <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
1. Include a provider in the `build` version
2. Update slf4j from 1.7.35 to 2.0.12